### PR TITLE
Tweak display of end_version

### DIFF
--- a/_layouts/plugin.svg
+++ b/_layouts/plugin.svg
@@ -15,11 +15,10 @@
     <text x="80" y="15" fill="#010101" fill-opacity=".3">ember-cli-deploy-versions</text>
     <text x="80" y="14">ember-cli-deploy-versions</text>
     <text x="195.5" y="15" fill="#010101" fill-opacity=".3">
-      {% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %}-{{page.end_version}}{% else %}+{% endif %}{% endif %}
+      {% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %}{% if page.end_version != page.start_version %}-{{page.end_version}}{% endif %}{% else %}+{% endif %}{% endif %}
     </text>
     <text x="195.5" y="14">
-      {% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %}-{{page.end_version}}{% else %}+{% endif %}
-      {% endif %}
+      {% if page.version_text %}{{page.version_text}}{% else %}{{page.start_version}}{% if page.end_version %}{% if page.end_version != page.start_version %}-{{page.end_version}}{% endif %}{% else %}+{% endif %}{% endif %}
     </text>
   </g>
 </svg>


### PR DESCRIPTION
Don't show an end version if it's the same as the start version.

* 0.5.1 (only 0.5.1)
* 0.5.1+ (0.5.1 or higher)
* 0.5.1-0.6.0 (between 0.5.1 and 0.6.0 inclusively)